### PR TITLE
adding a linting utility for this repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+.PHONY: help
+help:
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+.PHONY: test
+test: test-sh test-docker ## run all tests
+
+.PHONY: test-sh
+test-sh:
+ifeq (, $(shell which shellcheck))
+    $(error "please install shellcheck")
+endif
+	@echo "~~ testing shell/bash ~~"
+	@find . -name "*.sh" -exec shellcheck {} \;
+
+.PHONY: test-docker
+test-docker:
+ifeq (, $(shell which hadolint))
+    $(error "please install hadolint")
+endif
+	@echo "~~ testing dockerfiles ~~"
+	@find . -name "Dockerfile" -exec hadolint {} \;

--- a/README.md
+++ b/README.md
@@ -85,7 +85,11 @@ Docker specific scripts
 
 ### testing
 
-Testing specific scripts
+A helper function has been provided for you under `make test`. This will run
+two test suites:
+
+ - `shellcheck` runs on all files with a `.sh` extension
+ - `hadolint` runs on all `Dockerfile` files
 
 ## Contributing
 


### PR DESCRIPTION
adding a linting utility for this repo - I find both of these tools (`shellcheck` and `hadolint`) extremely valuable. hope you get some cool stuff from them too!

*What changes does this PR bring?*

Adds linting utility to shell, bash and docker. You will need to download the following tools to make use of this PR:

 - https://www.shellcheck.net/
 - https://github.com/hadolint/hadolint

*What are the relevant tickets?*

n/a

*Are tests included? (if applicable)*

Yes - run `make test`

*Types of review(s) required? (BE and/or FE)*

Static analysis
Run `make test` and validate that the recommendations make sense
